### PR TITLE
Lightgun offscreen position core option

### DIFF
--- a/src/osd/retro/libretro.c
+++ b/src/osd/retro/libretro.c
@@ -41,6 +41,7 @@ char RPATH[512];
 int serialize_size = 0; // memorize size of serialized savestate
 
 static char option_mouse[50];
+static char option_reload[50];
 static char option_cheats[50];
 static char option_nag[50];
 static char option_info[50];
@@ -136,6 +137,7 @@ void retro_set_audio_sample(retro_audio_sample_t cb) { }
 void retro_set_environment(retro_environment_t cb)
 {
    sprintf(option_mouse, "%s_%s", core, "mouse_mode");
+   sprintf(option_reload, "%s_%s", core, "reload_mode");
    sprintf(option_cheats, "%s_%s", core, "cheats_enable");
    sprintf(option_nag, "%s_%s",core,"hide_nagscreen");
    sprintf(option_info, "%s_%s",core,"hide_infoscreen");
@@ -152,7 +154,7 @@ void retro_set_environment(retro_environment_t cb)
    sprintf(option_auto_save,"%s_%s",core,"auto_save");
    sprintf(option_saves,"%s_%s",core,"saves");
    sprintf(option_throttle,"%s_%s",core,"throttle");
-  sprintf(option_nobuffer,"%s_%s",core,"nobuffer");
+   sprintf(option_nobuffer,"%s_%s",core,"nobuffer");
 
    static const struct retro_variable vars[] = {
     /* some ifdefs are redundant but I wanted 
@@ -171,6 +173,7 @@ void retro_set_environment(retro_environment_t cb)
     /* common for MAME/MESS/UME */
     { option_auto_save, "Auto save/load states; disabled|enabled" },
     { option_mouse, "XY device (Restart); none|lightgun|mouse" },
+    { option_reload, "Lightgun offscreen position; free|fixed (top left)|fixed (bottom right)" },
     { option_throttle, "Enable throttle; disabled|enabled" },
     { option_cheats, "Enable cheats; disabled|enabled" },
 //  { option_nobuffer, "Nobuffer patch; disabled|enabled" },
@@ -231,6 +234,19 @@ static void check_variables(void)
          mouse_mode = 1;
       if (!strcmp(var.value, "lightgun"))
          mouse_mode = 2;
+   }
+
+   var.key   = option_reload;
+   var.value = NULL;
+	
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (!strcmp(var.value, "free"))
+         reload_mode = 0;
+      if (!strcmp(var.value, "fixed (top left)"))
+         reload_mode = 1;
+      if (!strcmp(var.value, "fixed (bottom right)"))
+         reload_mode = 2;
    }
 
    var.key   = option_throttle;

--- a/src/osd/retro/libretro_shared.h
+++ b/src/osd/retro/libretro_shared.h
@@ -30,6 +30,7 @@ extern int retro_pause;
 extern bool experimental_cmdline;
 extern bool hide_gameinfo;
 extern int mouse_mode;
+extern int reload_mode;
 extern bool cheats_enable;
 extern bool alternate_renderer;
 extern bool boot_to_osd_enable;

--- a/src/osd/retro/retromain.c
+++ b/src/osd/retro/retromain.c
@@ -81,6 +81,7 @@ bool nobuffer_enable = false;
 
 bool hide_gameinfo = false;
 int mouse_mode = 0;
+int reload_mode = 0;
 bool cheats_enable = false;
 bool alternate_renderer = false;
 bool boot_to_osd_enable = false;
@@ -969,40 +970,64 @@ void process_lightgun_state(void)
       gun_2[i] = input_state_cb( i, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_AUX_A );
 	      
       if(gb1[i]==0 && gun_1[i])
-	  {
-	     gb1[i]=1;
-	     lightgunstate[i].lightgunBUT[0] = 0x80;	  
-	  }
+      {
+	 gb1[i]=1;
+	 lightgunstate[i].lightgunBUT[0] = 0x80;	  
+      }
       else if(gb1[i]==1 && !gun_1[i])
-	  {
-	     lightgunstate[i].lightgunBUT[0] = 0;	
-	     gb1[i]=0;
-	  }
+      {
+	 lightgunstate[i].lightgunBUT[0] = 0;	
+	 gb1[i]=0;
+      }
 	   
       if(gb2[i]==0 && gun_2[i])
-	  {
-	     gb2[i]=1;
-	     lightgunstate[i].lightgunBUT[1] = 0x80;	  
-	  }
+      {
+	 gb2[i]=1;
+	 lightgunstate[i].lightgunBUT[1] = 0x80;	  
+      }
       else if(gb2[i]==1 && !gun_2[i])
-	  {
-	     lightgunstate[i].lightgunBUT[1] = 0;	
-	     gb2[i]=0;
-	  }
+      {
+	 lightgunstate[i].lightgunBUT[1] = 0;	
+	 gb2[i]=0;
+      }
 
       lightgun_x[i] = input_state_cb(i, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_SCREEN_X);
       lightgun_y[i] = input_state_cb(i, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_SCREEN_Y);
 	
       lightgunLX[i] = lightgun_x[i]*2;;
       lightgunLY[i] = lightgun_y[i]*2;;
-	 
-      //Place the cursor at screen top left when detected as offscreen or when Gun Reload input activated
-      if (input_state_cb( i, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_IS_OFFSCREEN ) || input_state_cb( i, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_RELOAD ) )
-	  {
-	     lightgunLX[i] = -65534;
-	     lightgunLY[i] = -65534; 
-	  }
 
+      //Place the cursor at a corner of the screen designated by "Lightgun offscreen position" when the cursor touches a min/max value
+      if (input_state_cb( i, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_IS_OFFSCREEN ))
+      {
+         if (reload_mode == 1)
+	 {
+	    lightgunLX[i] = -65535;
+	    lightgunLY[i] = -65535;
+         }
+	 else if (reload_mode == 2)
+	 {
+	    lightgunLX[i] = 65535;
+	    lightgunLY[i] = 65535;
+	 }
+      }
+	   
+      //The LIGHTGUN_RELOAD input will fire a shot at the bottom-right corner if "Lightgun offscreen position" is set to "fixed (bottom right)"
+      //That same input will fire a shot at the top-left corner otherwise
+      //The reload feature of some games fails at the top-left corner
+      if (input_state_cb( i, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_RELOAD ) )
+      {
+         if (reload_mode == 2)
+         {
+	    lightgunLX[i] = 65535;
+	    lightgunLY[i] = 65535;
+         }
+	 else
+	 {
+	    lightgunLX[i] = -65535;
+	    lightgunLY[i] = -65535;
+	 }
+      }
    }
 }
 


### PR DESCRIPTION
Allow the user to determine where the cursor goes when the lightgun is detected as pointing offscreen. The Gun Reload Libretro input will fire into the corresponding corner and will still use top left if "free" is selected.